### PR TITLE
Add CRANsearcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ If you made a useful RStudio addin, feel free to make a pull request [on GitHub]
 | SeaClass | An interactive R GUI for classification problems | [SeaClass](https://github.com/ChrisDienes/SeaClass) | :x: | [Chris Dienes](https://github.com/ChrisDienes) | [Screenshots](https://github.com/ChrisDienes/SeaClass/blob/master/screen_shots.png) | |
 | rdoxygen | Create doxygen documentation for source code | [rdoxygen](https://github.com/nevrome/rdoxygen) | :white_check_mark: | [Clemens Schmid](https://github.com/nevrome) | | |
 | remedy | RStudio Addins to Simplify Markdown Writing | [remedy](https://github.com/ThinkR-open/remedy) | :x: | [ThinkR](https://thinkr.fr/) | [How it works](https://github.com/ThinkR-open/remedy/blob/master/README.md) | |
+| CRANsearcher | RStudio addin to search CRAN packages titles and descriptions | [CRANsearcher](https://github.com/RhoInc/CRANsearcher) | :white_check_mark: | [Rho Inc](https://github.com/RhoInc) | | |


### PR DESCRIPTION
This PR adds the helpful [CRANsearcher](https://github.com/RhoInc/CRANsearcher) RStudio add-in to the list, which I have found very useful when I need to search for R packages using keywords and other criteria.