### PR TITLE
Fix encoding issue on Windows

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -27,8 +27,10 @@ update_addins_file <- function() {
   mdfile <- get_md_file()
   htmlfile <- get_html_file()
   url <- "https://raw.githubusercontent.com/daattali/rstudio-addins/master/README.md"
-  curl::curl_download(url, destfile = mdfile)
-  rmarkdown::pandoc_convert(mdfile, to = "html", output = htmlfile)
+  writeLines("% addinslist", mdfile)
+  curl::curl_download(url, destfile = mdfile, mode = "ab")
+  rmarkdown::pandoc_convert(mdfile, to = "html", output = htmlfile,
+                            options = "-s")
 }
 
 # Assuming the addins list file exists, parse the markdown table and


### PR DESCRIPTION
I noticed a character encoding issue when running the `addinslist` addin on Windows, using code page 1252 (West European). The attached patch fixes the issue for me. The examples below are cropped screenshots of the list window. Note the quotes around "RStudio".
## Before fix
![addinstlist_encoding_crop1](https://user-images.githubusercontent.com/2980656/45880860-088bad00-bdb2-11e8-84fc-c505cab55a2e.png)
## After fix
![addinstlist_encoding_crop2](https://user-images.githubusercontent.com/2980656/45880905-25c07b80-bdb2-11e8-9c03-b36e2623ef6e.png)

I guess the problem would also occur on other operating systems when using a character set other than UTF-8 in the system locale.

The patch adds option `-s` (`--standalone`) to the `pandoc_convert` call. This creates an HTML file where the (UTF-8) encoding is marked, allowing `xml2::read_html` to do the right thing.

A pandoc metadata row is added to the beginning of the markdown file. This avoids a warning about a missing title. The `curl_download` call appends after the metadata row.